### PR TITLE
Implement From<bkey_s_c> trait for BkeySC

### DIFF
--- a/bch_bindgen/src/bkey.rs
+++ b/bch_bindgen/src/bkey.rs
@@ -125,6 +125,16 @@ impl<'a> From<&'a c::bkey_i> for BkeySC<'a> {
     }
 }
 
+impl<'a> From<&'a c::bkey_s_c> for BkeySC<'a> {
+    fn from(k: &'a c::bkey_s_c) -> Self {
+        BkeySC {
+            k:    unsafe { &*k.k },
+            v:    unsafe { &*k.v },
+            iter: PhantomData,
+        }
+    }
+}
+
 pub struct BkeySCToText<'a, 'b> {
     k:  &'a BkeySC<'a>,
     fs: &'b Fs,


### PR DESCRIPTION
BkeySC currently implements a From trait for the bkey_i bindgen/C struct, but not its own direct counterpart; bkey_s_c.   This implements the From trait for bkey_s_c as well.